### PR TITLE
Change define-{worker,cron} to create a plain Clojure function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ You configure the jobs using the `define-worker` macro:
   (log/infof "sum %s + %s = %s" x y (+ x y)))
 ```
 
-and put the job in the queue by calling the function with the same
-name:
+and put the job in the queue by calling the `schedule` function:
 
 ``` clj
-(log-sum 3 4)
-(log-sum 88 99)
+(schedule log-sum 3 4)
+(schedule log-sum 88 99)
 ```
 
 You may also run periodic jobs using `define-cron`
@@ -55,6 +54,9 @@ You may also run periodic jobs using `define-cron`
 (bt/define-cron heartbeat-every-5-minutes (* 1000 60 5) []
   (log/info "heartbeat"))
 ```
+
+Both `define-worker` and `define-cron` create a regular Clojure
+function of the same name.
 
 ### Servers
 

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -83,7 +83,7 @@
                        (log/debugf "job %s ready" job)
                        (recur))
                :stop (log/debugf "job %s stop" job)
-               (let [done-ch (chan 1)
+                     (let [done-ch (chan 1)
                            worker (submit-worker pool done-ch msg)]
                        (let [[done? port] (alts! [done-ch (timeout
                                                            (:timeout-ms master-cf))])]

--- a/test/backtick/test/core_test.clj
+++ b/test/backtick/test/core_test.clj
@@ -44,6 +44,10 @@
 (define-cron my-test-cron (* 1234 100 60) []
   (reset! my-atom 'cron))
 
-(deftest perform-test
-  (register "perform-test-job" (fn [x] x))
-  (perform "perform-test-job" 88))
+(defn schedule-test-job [x]
+  x)
+
+(deftest schedule-test
+  (register "schedule-test-job" schedule-test-job)
+  (schedule schedule-test-job 88)
+  (schedule my-test-worker 2 3))


### PR DESCRIPTION
- The function is still registered with a unique string that we store
  in the database
- Rename perform to schedule
- schedule is called with a function object instead of a name
