### PR TITLE
Dynamic *job-id* accessible by workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ queue and then running jobs from that queue.  There is one thread that
 polls Postgres and then hands the job to be processed by a separate
 thread pool.
 
-Any data needed for the job is encoded as a JSON object in the
-Postgres table.
+Any data needed for the job is encoded as an EDN object in the Postgres table.
 
 When a job is completed, it is marked in the queue as done.  If the
 job fails, a recurring job will revive the dead one and place it back
@@ -86,6 +85,13 @@ in the queue.
 Polling isn't a great way to run a high volume queue, but using a
 Postgres table has the advantage of being simple, stable, and being
 able to easily handle our load.
+
+## Glossary
+
+- Worker: A function that's registered with Backtick.
+- Job: A unit of work that is scheduled to be run. Running a job causes a worker to be invoked.
+- Runner: A process that executes a job.
+- Cron: A job that recurs based on the time.
 
 ## Authors
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.4.1"
+  "0.4.2"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -5,13 +5,11 @@
    [backtick.db :as db]
    [clj-time.core :as time]
    [clj-time.coerce :refer [to-sql-time to-date-time]]
-   [clojure.core.async :as async :refer [chan alts! alts!!
-                                         <!! >!! <! >! close!
-                                         go go-loop timeout]]
+   [clojure.core.async :as async :refer [chan alts! alts!! >!! <! >! go-loop timeout]]
    [clojure.edn :as edn]
    [clojure.tools.logging :as log]
    [iter.core :refer [iter iter*]])
-  (:import (java.util.concurrent Executors TimeUnit)))
+  (:import java.util.concurrent.Executors))
 
 (defn cron-add
   "Add a cron job to the DB.  The job is started for the
@@ -63,24 +61,20 @@
                                (>!! ch :done)
                                (log/debugf "Running job %s %s ... done sent" id name)))))
         (do
-          (log/errorf "No worker %s registered, discarding job" name)
+          (log/errorf "No worker %s registered, discarding job %s" name id)
           (>!! ch :done)
           nil))))
 
-;;;
-;;; job
-;;;
-
-(defn- start-jobs [pool pool-size job-ch]
-  (log/debugf "start-jobs")
-  (iter* (foreach job (range pool-size))
+(defn- start-runners [pool pool-size job-ch]
+  (log/debugf "start-runners")
+  (iter* (foreach r (range pool-size))
          (go-loop []
            (let [msg (<! job-ch)]
              (condp = msg
                :ping (do
-                       (log/debugf "job %s ready" job)
+                       (log/debugf "runner %s ready" r)
                        (recur))
-               :stop (log/debugf "job %s stop" job)
+               :stop (log/debugf "runner %s stop" r)
                (let [done-ch (chan 1)
                      worker (submit-worker pool done-ch msg)
                      [done? port] (alts! [done-ch (timeout (:timeout-ms master-cf))])]
@@ -89,8 +83,11 @@
                    (do
                      (when worker
                        (.cancel worker true))
-                     (log/infof "job %s timeout: %s %s" job (:id msg) (:name msg))))
-                 (log/debugf "start-jobs: waiting")
+                     (log/infof "runner %s timed out job: %s %s"
+                                r
+                                (:id msg)
+                                (:name msg))))
+                 (log/debugf "start-runners: waiting")
                  (recur)))))))
 
 (def ^:private cron-checked (atom 0))
@@ -186,7 +183,7 @@
             (log/infof "Backlog starting")
             (let [pool (Executors/newFixedThreadPool pool-size (make-thread-factory))
                   job-ch (chan)]
-              (start-jobs pool pool-size job-ch)
+              (start-runners pool pool-size job-ch)
               (run-queue pool-size job-ch keep-running-queue?)
               (.shutdown pool)
               (log/infof "Shutdown complete")))]


### PR DESCRIPTION
Useful for logging and debugging. See commit log for more.
