### PR TITLE
Fix recurring BatchUpdateErrors on restart

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.4.2"
+  "0.4.3"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -43,7 +43,7 @@ where id = :id and state = 'running'
 -- name: queue-requeue-job!
 -- Put a job back in the queue that did not finish
 update backtick_queue
-set state = 'queued', priority = :priority, update_at = now()
+set state = 'queued', priority = :priority, updated_at = now()
 where id = :id and state = 'running'
 
 -- name: queue-delete-old-jobs!

--- a/test/backtick/test/cleaner_test.clj
+++ b/test/backtick/test/cleaner_test.clj
@@ -1,0 +1,41 @@
+(ns backtick.test.cleaner-test
+  (:require
+   [clj-time.core :as t]
+   [clj-time.coerce :as tc]
+   [clojure.java.jdbc :as jdbc]
+   [clojure.test :refer :all]
+   [backtick.cleaner :as cleaner]
+   [backtick.db :as db]))
+
+(def now        (tc/to-sql-time (t/now)))
+(def previously (tc/to-sql-time (t/minus (t/now) (t/hours 1))))
+
+(def backtick-queue-rows
+  [[:id :name :priority :state :tries :data :started_at :created_at :updated_at]
+   [301 "foo" previously "running" 1 "[]\n" previously previously previously]
+   [302 "bar" previously "queued" 1 "[]\n" previously previously previously]
+   ])
+
+(defn drain-queue []
+  (jdbc/delete! db/spec :backtick_queue []))
+
+(defn db-fixtures [f]
+  (drain-queue)
+  (apply jdbc/insert! db/spec :backtick_queue backtick-queue-rows)
+  (f)
+  (drain-queue))
+
+(use-fixtures :once db-fixtures)
+
+(deftest revive-test
+  (cleaner/revive)
+  (let [[foo bar] (jdbc/query db/spec "SELECT * FROM backtick_queue ORDER BY id ASC")]
+    ;; foo
+    (is (= (:state foo) "queued"))
+    (is (.after (:priority foo) now))
+    (is (.after (:updated_at foo) now))
+    ;; bar
+    (is (= (:state bar) "queued"))
+    (is (= (:priority bar) previously))
+    (is (= (:updated_at bar) previously))
+    ))

--- a/test/backtick/test/prop_test.clj
+++ b/test/backtick/test/prop_test.clj
@@ -12,6 +12,15 @@
 
 (use-fixtures :once fixtures/wrap-fixture-data)
 
+(defn wrap-run-bt-instance [f]
+  (let [runner1 (bt/start)
+        runner2 (bt/start)]
+    (f)
+    (runner1) ; shutdown
+    (runner2)))
+
+(use-fixtures :each wrap-run-bt-instance)
+
 (defn exec-workers [ints]
   (let [state (atom #{})
         ch (chan)
@@ -32,9 +41,6 @@
           (alts!! [done (timeout 10000)])))
       (finally (bt/unregister name)))
     @state))
-
-(defonce runner1 (bt/start))
-(defonce runner2 (bt/start))
 
 (defspec exec-test
   10


### PR DESCRIPTION
We've been seeing this error in all running instances with some
regularity:

```
WARN  | backtick.engine |
Unable to run job backtick.core/revive-killed-jobs
java.sql.BatchUpdateException: Batch entry 0 update backtick_queue
set state = 'queued', priority = '2016-02-10 15:55:31.437000 -08:00:00',
update_at = now()
where id = 242 and state = 'running' was aborted.
```

Turns out it was a single character typo. Fixed.
