### PR TITLE
bug fix: put the id in the cron payload jobs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.4.3"
+  "0.4.4"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [
@@ -15,7 +15,6 @@
    [org.slf4j/slf4j-log4j12 "1.7.7"]
    [yesql "0.5.1"]
    ]
-  :jar-exclusions [#"^migrations/"]
   :plugins [[com.jakemccrary/lein-test-refresh "0.10.0"]]
   :profiles {:test {:jvm-opts ["-Dclams.env=test"]}
              :production {:jvm-opts ["-Dclams.env=production"]}})

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -17,12 +17,12 @@ from (
 where  bq.id = sub.id
 returning bq.*;
 
--- name: queue-insert!
+-- name: queue-insert<!
 -- Insert a new job element
 insert into backtick_queue
-  (name, priority, state, data, created_at, updated_at)
+  (name, priority, state, data, started_at, created_at, updated_at)
 values
-  (:name, :priority, :state, :data, now(), now());
+  (:name, :priority, :state, :data, now(), now(), now());
 
 -- name: queue-finish!
 -- Mark a job as finished
@@ -32,7 +32,9 @@ where  id = :id and state = 'running'
 
 -- name: queue-killed-jobs
 -- Find jobs that haven't finished in time
-select * from backtick_queue where state = 'running' and started_at < :killtime
+select * from backtick_queue
+where state = 'running'
+   and (started_at is null or started_at < :killtime)
 
 -- name: queue-abort-job!
 -- Abort a job that has been tried too many times

--- a/test/backtick/test/engine_test.clj
+++ b/test/backtick/test/engine_test.clj
@@ -6,13 +6,19 @@
 
 (deftest add-test
   (let [spy (atom [])]
-    (with-redefs [backtick.db/queue-insert! #(reset! spy %)]
+    (with-redefs [backtick.db/queue-insert<! #(reset! spy %)]
       (engine/add "foo" {:bar "baz" :quux 123 :flim :flam}))
     (is (contains? @spy :priority))
     (is (= (dissoc @spy :priority)
            {:name "foo"
             :state "queued"
-            :data "{:bar \"baz\", :quux 123, :flim :flam}\n"}))))
+            :data "{:bar \"baz\", :quux 123, :flim :flam}\n"})))
+  (let [inserted (engine/add "foo" [1 2 3])]
+    (is (= 0 (:tries inserted)))
+    (is (:started_at inserted))
+    (is (> (:id inserted) 0))
+    (is (= "queued" (:state inserted)))
+    (is (= "[1 2 3]\n" (:data inserted)))))
 
 (defprotocol FakeThreadPool
   (submit [this job]))


### PR DESCRIPTION
We were using id from the cron table, not the id from the queue table.
