### PR TITLE
Start *job-id* at nil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
 (defproject ctdean/backtick
-  "0.4.5"
+  "0.4.6"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [
    [clams "0.2.6" :exclusions [ring]]
    [clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"]
-   [ctdean/iter "0.10.1"]
+   [ctdean/iter "0.10.2"]
    [org.clojure/clojure "1.7.0"]
    [org.clojure/core.async "0.2.374"]
    [org.clojure/java.jdbc "0.4.2"]

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -47,7 +47,7 @@
                               name
                               (swap! thread-counter inc)))))))
 
-(def ^:dynamic *job-id*)
+(def ^:dynamic *job-id* nil)
 
 (defn submit-worker [pool ch msg]
   (let [{id :id name :name data :data} msg


### PR DESCRIPTION
- This prevents unbound warnings in the repl.
