### PR TITLE
Failed jobs are requeued immediately

### DIFF
--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -30,6 +30,11 @@ update backtick_queue
 set    state = 'done', finished_at = now()
 where  id = :id and state = 'running'
 
+-- name: queue-running-job
+-- Find a job that is still running
+select * from backtick_queue
+where id = :id and state = 'running'
+
 -- name: queue-killed-jobs
 -- Find jobs that haven't finished in time
 select * from backtick_queue
@@ -39,7 +44,7 @@ where state = 'running'
 -- name: queue-abort-job!
 -- Abort a job that has been tried too many times
 update backtick_queue
-set state = 'exceeded', finished_at = now()
+set state = 'exceeded', updated_at = now(), finished_at = now()
 where id = :id and state = 'running'
 
 -- name: queue-requeue-job!

--- a/src/backtick/cleaner.clj
+++ b/src/backtick/cleaner.clj
@@ -49,8 +49,8 @@
   ([id tries]
    (if (exceeded? tries)
        (db/queue-abort-job! {:id id})
-       (db/queue-requeue-job!{:id id
-                              :priority (revive-priority tries)}))))
+       (db/queue-requeue-job! {:id id
+                               :priority (revive-priority tries)}))))
 
 (defn revive
   "Revive jobs that never finished.  Will be run from a backtick job."

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -1,6 +1,7 @@
 (ns backtick.engine
   "@ctdean"
   (:require
+   [backtick.cleaner :as cleaner]
    [backtick.conf :refer [master-cf]]
    [backtick.db :as db]
    [clj-time.core :as time]
@@ -58,7 +59,8 @@
                              (binding [*job-id* id]
                                (apply f data))
                              (catch Throwable e
-                               (log/warnf e "Unable to run job %s %s" id name))
+                               (log/warnf e "Unable to run job %s %s" id name)
+                               (cleaner/revive-one-job id))
                              (finally
                                (log/debugf "Running job %s %s ... done" id name)
                                (>!! ch :done)
@@ -89,7 +91,8 @@
                      (log/infof "runner %s timed out job: %s %s"
                                 r
                                 (:id msg)
-                                (:name msg))))
+                                (:name msg))
+                     (cleaner/revive-one-job (:id msg))))
                  (log/debugf "start-runners: waiting")
                  (recur)))))))
 

--- a/test/backtick/test/cleaner_test.clj
+++ b/test/backtick/test/cleaner_test.clj
@@ -12,8 +12,10 @@
 
 (def backtick-queue-rows
   [[:id :name :priority :state :tries :data :started_at :created_at :updated_at]
-   [301 "foo" previously "running" 1 "[]\n" previously previously previously]
-   [302 "bar" previously "queued" 1 "[]\n" previously previously previously]
+   [301 "j1" previously "running" 1 "[]\n" previously previously previously]
+   [302 "j2" previously "queued" 1 "[]\n" previously previously previously]
+   [303 "j3" previously "running" Integer/MAX_VALUE "[]\n" previously previously previously]
+   [304 "j4" previously "running" 2 "[]\n" previously previously previously]
    ])
 
 (defn drain-queue []
@@ -27,15 +29,36 @@
 
 (use-fixtures :once db-fixtures)
 
+(deftest revive-one-job-test
+  ;; Just in case revive already ran
+  (jdbc/execute! db/spec ["UPDATE backtick_queue SET state = 'running' WHERE id = 304"])
+  (let [[before] (jdbc/query db/spec "SELECT * FROM backtick_queue WHERE id = 304")]
+    (cleaner/revive-one-job 304)
+    (let [[after] (jdbc/query db/spec "SELECT * FROM backtick_queue WHERE id = 304")]
+      (is (= 304 (:id before) (:id after)))
+      (is (= "running" (:state before)))
+      (is (= "queued" (:state after)))
+      (is (= (:tries before) (:tries after)))
+      (is (.before (:priority before) (:priority after)))))
+  ;; Missing job should not throw an error
+  (cleaner/revive-one-job -1))
+
 (deftest revive-test
   (cleaner/revive)
-  (let [[foo bar] (jdbc/query db/spec "SELECT * FROM backtick_queue ORDER BY id ASC")]
-    ;; foo
-    (is (= (:state foo) "queued"))
-    (is (.after (:priority foo) now))
-    (is (.after (:updated_at foo) now))
-    ;; bar
-    (is (= (:state bar) "queued"))
-    (is (= (:priority bar) previously))
-    (is (= (:updated_at bar) previously))
+  (let [[j1 j2 j3] (jdbc/query
+                    db/spec
+                    "SELECT * FROM backtick_queue WHERE id in (301, 302, 303) ORDER BY id ASC")]
+    ;; j1
+    (is (= (:state j1) "queued"))
+    (is (.after (:priority j1) now))
+    (is (.after (:updated_at j1) now))
+    (is (not (:finished_at j1)))
+    ;; j2
+    (is (= (:state j2) "queued"))
+    (is (= (:priority j2) previously))
+    (is (= (:updated_at j2) previously))
+    (is (not (:finished_at j2)))
+    ;; j3
+    (is (= (:state j3) "exceeded"))
+    (is (:finished_at j3))
     ))


### PR DESCRIPTION
- If a jobs fails, requeue it immediately. Don't wait for the cleaner to run.
- Reschedule the job with a time range, where the time is a spread
  across a uniform distribution
