### PR TITLE
Fix remove-old-jobs cleaner

### DIFF
--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -55,7 +55,7 @@ where id = :id and state = 'running'
 
 -- name: queue-delete-old-jobs!
 -- Delete very old jobs
-delete from backtick_queue where finished_at > :finished
+delete from backtick_queue where finished_at < :finished
 
 -- name: recurring-update-next!
 -- Update the next runtime for an existing recurring job


### PR DESCRIPTION
It looks like there was a sign-reversal typo in the SQL file; as a result, old
jobs were never getting removed from the backtick_queue. This fixes that and
adds a test for the old job removing function.
