### PR TITLE
Wait to retry requeued jobs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.5.1"
+  "0.5.2"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -49,9 +49,12 @@ where id = :id and state = 'running'
 
 -- name: queue-requeue-job!
 -- Put a job back in the queue that did not finish
-update backtick_queue
-set state = 'queued', priority = :priority, updated_at = now()
-where id = :id and state = 'running'
+UPDATE backtick_queue
+SET state = 'queued',
+    priority = :priority,
+    run_at = :run_at,
+    updated_at = now()
+WHERE id = :id AND state = 'running'
 
 -- name: queue-delete-old-jobs!
 -- Delete very old jobs


### PR DESCRIPTION
Previously when a job failed and was requeued, a timeout was calculated and set
as the job's new priority. But the priority is simply an ordering, not a hard
time constraint (that's what run_at is for). This would have worked as a timeout
so long as the queue runners were saturated (so, rarely). This diff sets a
run_at timeout for requeued jobs such that Backtick will guarantee a requeued
job isn't re-run until the timeout elapses, regardless of queue saturation.
