### PR TITLE
Merge priority and run_at

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.5.1"
+  "0.5.2"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/resources/backtick/migrations/105-at-jobs.down.sql
+++ b/resources/backtick/migrations/105-at-jobs.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE backtick_queue ADD COLUMN run_at timestamp without time zone;
+
+CREATE INDEX backtick_queue_run_at_index ON backtick_queue (run_at);

--- a/resources/backtick/migrations/105-at-jobs.up.sql
+++ b/resources/backtick/migrations/105-at-jobs.up.sql
@@ -1,0 +1,3 @@
+DROP INDEX backtick_queue_run_at_index;
+
+ALTER TABLE backtick_queue DROP COLUMN run_at;

--- a/src/backtick/cleaner.clj
+++ b/src/backtick/cleaner.clj
@@ -34,7 +34,7 @@
          (let [[low hi] (revive-range-ms tries)]
            (printf "%2d %12s %12s\n" tries (time-unit low) (time-unit hi)))))
 
-(defn- revive-priority [tries]
+(defn- revive-at [tries]
   (let [[lo hi] (revive-range-ms tries)
         p (+ lo (rand-int (- hi lo)))]
     (to-sql-time (t/plus (t/now) (t/millis p)))))
@@ -47,9 +47,9 @@
      (log/errorf "No id for revive-one-job: %s" id)))
   ([id tries]
    (if (exceeded? tries)
-       (db/queue-abort-job! {:id id})
-       (db/queue-requeue-job! {:id id
-                               :priority (revive-priority tries)}))))
+     (db/queue-abort-job! {:id id})
+     (db/queue-requeue-job! {:id id
+                             :priority (to-sql-time (t/now))}))))
 
 (defn revive
   "Revive jobs that never finished.  Will be run from a backtick job."

--- a/src/backtick/core.clj
+++ b/src/backtick/core.clj
@@ -4,7 +4,6 @@
    [backtick.conf :refer [master-cf]]
    [backtick.cleaner :as cleaner]
    [backtick.engine :as engine]
-   [clj-time.core :as t]
    [clojure.tools.logging :as log])
   (:gen-class))
 
@@ -59,6 +58,7 @@
   "Schedule a job on the Backtick queue to be run at the appointed time. Worker can be
    either the worker's registered name or a reference to the worker function itself."
   [time worker & args]
+  ;; Implementation detail: A priority of NULL means (now).
   (when-let [name (resolve-worker worker)]
     (engine/add time name args)))
 

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -31,8 +31,7 @@
   [time name data]
   (assert (or (nil? data) (seq data)) "Job data must be a seq or nil.")
   (db/queue-insert<! {:name name
-                      :priority (to-sql-time (t/now))
-                      :run_at (to-sql-time time)
+                      :priority (when time (to-sql-time time))
                       :state "queued"
                       :tries 0
                       :data (prn-str data)}))
@@ -133,7 +132,6 @@
                 inserted (db/queue-insert<! {:name (:name payload)
                                              :state "running"
                                              :priority (to-sql-time (t/now))
-                                             :run_at nil
                                              :tries 1
                                              :data (prn-str [])})]
             (db/recurring-update-next! (-> (select-keys payload [:id])

--- a/test/backtick/test/cleaner_test.clj
+++ b/test/backtick/test/cleaner_test.clj
@@ -32,9 +32,8 @@
 (use-fixtures :each db-fixtures)
 
 (deftest revive-one-job-test
-  ;; Just in case revive already ran
-  (jdbc/execute! db/spec ["UPDATE backtick_queue SET state = 'running' WHERE id = 304"])
-  (let [[before] (jdbc/query db/spec "SELECT * FROM backtick_queue WHERE id = 304")]
+  (let [[before] (jdbc/query db/spec "SELECT * FROM backtick_queue WHERE id = 304")
+        now (t/now)]
     (cleaner/revive-one-job 304)
     (let [[after] (jdbc/query db/spec "SELECT * FROM backtick_queue WHERE id = 304")]
       (is (= 304 (:id before) (:id after)))

--- a/test/backtick/test/core_test.clj
+++ b/test/backtick/test/core_test.clj
@@ -53,7 +53,6 @@
   (schedule schedule-test-job-1 88)
   (schedule my-test-worker 2 3)
   (let [jobs (db-query-bt-queue)]
-    (is (every? (comp nil? :run_at) jobs))
     (is (= [nil [88] [2 3]] (->> jobs (map :data) (map edn/read-string))))))
 
 (deftest schedule-at-test
@@ -66,7 +65,7 @@
     (schedule-at later schedule-test-job-1 88)
     (schedule-at laterer my-test-worker 2 3)
     (let [jobs (db-query-bt-queue)]
-      (is (= (map tc/to-sql-time [now later laterer]) (map :run_at jobs)))
+      (is (= (map tc/to-sql-time [now later laterer]) (map :priority jobs)))
       (is (= [nil [88] [2 3]] (->> jobs (map :data) (map edn/read-string)))))))
 
 (deftest schedule-recurring-test

--- a/test/backtick/test/engine_test.clj
+++ b/test/backtick/test/engine_test.clj
@@ -12,14 +12,12 @@
         run-at (t/plus now (t/hours 1))]
     (with-redefs [backtick.db/queue-insert<! #(reset! spy %)]
       (engine/add run-at "foo" {:bar "baz" :quux 123 :flim :flam}))
-    (is (= (dissoc @spy :priority :run_at)
+    (is (= (dissoc @spy :priority)
            {:name "foo"
             :state "queued"
             :tries 0
             :data "{:bar \"baz\", :quux 123, :flim :flam}\n"}))
-    (is (t/within? (t/interval now (t/plus now (t/seconds 1)))
-                   (tc/from-sql-time (@spy :priority))))
-    (is (= (@spy :run_at) (tc/to-sql-time run-at))))
+    (is (= (@spy :priority) (tc/to-sql-time run-at))))
   (let [inserted (engine/add (t/now) "foo" [1 2 3])]
     (is (= 0 (:tries inserted)))
     (is (:started_at inserted))


### PR DESCRIPTION
It used to be that priority was used when a job was created and when
it was retried.  And then purely as the ordering of jobs.  Now we wish
to only retry on a specific time schedule, so the only time when we
would want to run a job ASAP would be when the initial job is created.

We can accomplish this by getting rid of run_at and only running jobs
when priority <= now.
