### PR TITLE
Allow jobs to be canceled before they are executed

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.5.3"
+  "0.5.4"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -1,4 +1,3 @@
-
 -- name: queue-pop
 -- Pop the top element off the backtick queue
 update backtick_queue bq
@@ -55,9 +54,17 @@ SET state = 'queued',
     updated_at = now()
 WHERE id = :id AND state = 'running'
 
+-- name: queue-cancel-all-jobs!
+-- Cancel all queued jobs so that they won't run.
+UPDATE backtick_queue
+SET state = 'canceled', updated_at = now()
+WHERE state = 'queued'
+
 -- name: queue-delete-old-jobs!
--- Delete very old jobs
-delete from backtick_queue where finished_at < :finished
+-- Delete very old jobs.
+DELETE FROM backtick_queue
+WHERE (state = 'done' AND finished_at < :finished) OR
+      (state = 'canceled' AND updated_at < :finished)
 
 -- name: recurring-update-next!
 -- Update the next runtime for an existing recurring job

--- a/src/backtick/cleaner.clj
+++ b/src/backtick/cleaner.clj
@@ -65,7 +65,7 @@
 ;;;
 
 (defn remove-old
-  "Remove old successful jobs from the database."
+  "Remove old successful and canceled jobs from the database."
   []
   (let [time (to-sql-time (t/minus (t/now)
                                    (t/millis (:max-completed-ms master-cf))))]

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -200,3 +200,9 @@
     (fn []
       (reset! keep-running-queue? false)
       @t)))
+
+(defn cancel-all
+  "Cancels all queued jobs so that they will never run.
+   Be careful, this is dangerous!"
+  []
+  (db/queue-cancel-all-jobs!))

--- a/test/backtick/test/cleaner_test.clj
+++ b/test/backtick/test/cleaner_test.clj
@@ -18,6 +18,7 @@
    [302 "j2" prev "queued" 1 "[]\n" prev nil prev prev]
    [303 "j3" prev "running" Integer/MAX_VALUE "[]\n" prev nil prev prev]
    [304 "j4" prev "running" 2 "[]\n" prev nil prev prev]
+   [305 "j5" prev2 "canceled" 0 "[]\n" prev2 prev2 prev2 prev2]
    ])
 
 (defn drain-queue []


### PR DESCRIPTION
Adds a new `canceled` state. Jobs that are set as `canceled` will not be
dequeued for execution and will eventually get cleaned up by the existing
cleaner. This shouldn't generally be necessary but the ability to drain the
queue and just skip all its jobs can be useful for debugging or error recovery
in a running queue (where it's not practical to go manually poking around the database).
