### PR TITLE
Zero recurring interval disables the job

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject ctdean/backtick
-  "0.7.1"
+  "0.7.2"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -78,7 +78,7 @@ SELECT * FROM backtick_recurring;
 
 -- name: recurring-delete!
 -- Delete a recurring job
-delete from backtick_recurring where id = :id
+delete from backtick_recurring where name = :name
 
 -- name: recurring-upsert-interval
 -- Update the interval on an existing recurring job or insert a new one

--- a/src/backtick/core.clj
+++ b/src/backtick/core.clj
@@ -12,7 +12,7 @@
   "Schedule a job on the Backtick queue to be run at the appointed time. Worker can be
    either the worker's registered name or a reference to the worker function itself."
   [time worker & args]
-  ;; Implementation detail: A priority of NULL means (now).
+  ;; Implementation detail: A priority of nil means now.
   (when-let [name (resolve-worker->name worker)]
     (engine/add time name args)))
 
@@ -23,9 +23,11 @@
   (apply schedule-at nil worker args))
 
 (defn schedule-recurring
-  "Schedule a job to be run on the Backtick queue on a recurring basis, every msec
-   milliseconds, starting for the first time msec milliseconds from now. Worker can be
-   either the worker's registered name or a reference to the worker function itself."
+  "Schedule a job to be run on the Backtick queue on a recurring basis, every
+   msec milliseconds, starting for the first time msec milliseconds from now.
+   Worker can be either the worker's registered name or a reference to the
+   worker function itself. If msec is set to zero the job will be considered
+   disabled and will not be run."
   [msec worker & args]
   (assert (empty? args) "Recurring jobs may not take arguments.")
   (when-let [name (resolve-worker->name worker)]

--- a/src/backtick/engine.clj
+++ b/src/backtick/engine.clj
@@ -23,10 +23,14 @@
   (let [enabled (not= 0 interval)
         real-interval (max (:recurring-resolution-ms master-cf) interval)
         next (to-sql-time (t/plus (t/now) (t/millis real-interval)))]
-    (when enabled
+    (if enabled
       (db/recurring-upsert-interval {:name name
                                      :interval (int real-interval)
-                                     :next next}))))
+                                     :next next})
+      ;; I know it's strange to delete a job in a function called "add",
+      ;; but this ensures that a newly disabled recurring job's old
+      ;; database entry is disabled to match.
+      (db/recurring-delete! {:name name}))))
 
 (defn recurring-map
   "All the recurring jobs as a map."


### PR DESCRIPTION
Setting a recurring job's interval to zero (`0`) disables the job so that it
will never be run. This is a quick and convenient way to disable a job for
debugging or configuration purposes.
