### PR TITLE
Update outdated dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,20 @@
 (defproject ctdean/backtick
-  "0.7.2"
+  "0.7.3"
   :description "Background job processing for Clojure using Postgres"
   :dependencies
   [
-   [clj-time "0.11.0"]
+   [clj-time "0.12.0"]
    [clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"]
    [conf "0.9.1" :exclusions [org.clojure/clojure]]
-   [ctdean/iter "0.10.3"]
-   [org.clojure/clojure "1.7.0"]
-   [org.clojure/core.async "0.2.374"]
-   [org.clojure/java.jdbc "0.4.2"]
+   [ctdean/iter "0.11.0"]
+   [org.clojure/clojure "1.8.0"]
+   [org.clojure/core.async "0.2.391"]
+   [org.clojure/java.jdbc "0.6.1"]
    [org.clojure/test.check "0.9.0"]
    [org.clojure/tools.logging "0.3.1"]
-   [org.postgresql/postgresql "9.4.1208"]
-   [org.slf4j/slf4j-log4j12 "1.7.16"]
-   [st/common "0.10.5"]
+   [org.postgresql/postgresql "9.4.1210"]
+   [org.slf4j/slf4j-log4j12 "1.7.21"]
+   [st/common "0.10.6"]
    [yesql "0.5.2"]
    ]
   :jar-exclusions [#"^migrations/"]


### PR DESCRIPTION
Except for yesql: v0.5.3 seems to have some weird macro compilation errors that I'm not really interested in solving right now.
