### PR TITLE
Remove dependency on st/common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,11 @@ all: run
 run:
 	lein trampoline run
 
-# Create the tables and link migrations
+# Create the tables
 init:
 	- createuser -s postgres -h localhost
 	- createdb -Upostgres -h localhost $(DATABASE)
 	- createdb -Upostgres -h localhost $(DATABASE)_test
-	- ln -ns backtick/migrations resources/migrations
 
 # Drop the tables
 drop:
@@ -23,9 +22,15 @@ drop:
 
 migrate:
 	DATABASE_URL="jdbc:postgresql://localhost:5432/$(DATABASE)?user=postgres" \
-	    lein run -m common.db.migrate migrate
+	    lein migrate
 	DATABASE_URL="jdbc:postgresql://localhost:5432/$(DATABASE)_test?user=postgres" \
-	    lein run -m common.db.migrate migrate
+	    lein migrate
+
+rollback:
+	DATABASE_URL="jdbc:postgresql://localhost:5432/$(DATABASE)?user=postgres" \
+	    lein rollback
+	DATABASE_URL="jdbc:postgresql://localhost:5432/$(DATABASE)_test?user=postgres" \
+	    lein rollback
 
 # Nuke the existing databases and recreate
 rebuild: drop init migrate

--- a/dev/backtick/db/migrate.clj
+++ b/dev/backtick/db/migrate.clj
@@ -1,0 +1,14 @@
+(ns backtick.db.migrate
+  (:require [conf.core :as conf]
+            [ragtime.jdbc :as jdbc]
+            [ragtime.repl :as repl]))
+
+(defn load-config []
+  {:datastore (jdbc/sql-database (conf/get :database-url))
+   :migrations (jdbc/load-resources "backtick/migrations")})
+
+(defn migrate []
+  (repl/migrate (load-config)))
+
+(defn rollback []
+  (repl/rollback (load-config)))

--- a/project.clj
+++ b/project.clj
@@ -1,22 +1,21 @@
-(defproject ctdean/backtick
-  "0.7.4"
+(defproject ctdean/backtick "0.7.5"
   :description "Background job processing for Clojure using Postgres"
-  :dependencies
-  [
-   [clj-time "0.12.0"]
-   [clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"]
-   [conf "0.9.1" :exclusions [org.clojure/clojure]]
-   [org.clojure/clojure "1.8.0"]
-   [org.clojure/core.async "0.2.391"]
-   [org.clojure/java.jdbc "0.6.1"]
-   [org.clojure/test.check "0.9.0"]
-   [org.clojure/tools.logging "0.3.1"]
-   [org.postgresql/postgresql "9.4.1210"]
-   [org.slf4j/slf4j-log4j12 "1.7.21"]
-   [st/common "0.10.6"]
-   [yesql "0.5.2"]
-   ]
+  :dependencies [[clj-time "0.12.0"]
+                 [clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"]
+                 [conf "0.9.1" :exclusions [org.clojure/clojure]]
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.391"]
+                 [org.clojure/java.jdbc "0.6.1"]
+                 [org.clojure/test.check "0.9.0"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [org.postgresql/postgresql "9.4.1211"]
+                 [org.slf4j/slf4j-log4j12 "1.7.21"]
+                 [yesql "0.5.3"]]
   :jar-exclusions [#"^migrations/"]
   :plugins [[com.jakemccrary/lein-test-refresh "0.10.0"]]
-  :profiles {:test {:jvm-opts ["-Dconf.env=test"]}
-             :production {:jvm-opts ["-Dconf.env=production"]}})
+  :profiles {:dev {:dependencies [[ragtime "0.6.3"]]
+                   :source-paths ["dev"]}
+             :test {:jvm-opts ["-Dconf.env=test"]}
+             :production {:jvm-opts ["-Dconf.env=production"]}}
+  :aliases {"migrate"  ["run" "-m" "backtick.db.migrate/migrate"]
+            "rollback" ["run" "-m" "backtick.db.migrate/rollback"]})

--- a/test/backtick/test/cleaner_test.clj
+++ b/test/backtick/test/cleaner_test.clj
@@ -11,22 +11,23 @@
 (def prev  (tc/to-sql-time (t/minus (t/now) (t/hours 1))))
 (def prev2 (tc/to-sql-time (t/minus (t/now) (t/days 8))))
 
+(def backtick-queue-cols
+  [:id :name :priority :state :tries :data :started_at :finished_at :created_at :updated_at])
+
 (def backtick-queue-rows
-  [[:id :name :priority :state :tries :data :started_at :finished_at :created_at :updated_at]
-   [300 "j0" prev2 "done" 1 "[]\n" prev2 prev2 prev2 prev2]
+  [[300 "j0" prev2 "done" 1 "[]\n" prev2 prev2 prev2 prev2]
    [301 "j1" prev "running" 1 "[]\n" prev nil prev prev]
    [302 "j2" prev "queued" 1 "[]\n" prev nil prev prev]
    [303 "j3" prev "running" Integer/MAX_VALUE "[]\n" prev nil prev prev]
    [304 "j4" prev "running" 2 "[]\n" prev nil prev prev]
-   [305 "j5" prev2 "canceled" 0 "[]\n" prev2 prev2 prev2 prev2]
-   ])
+   [305 "j5" prev2 "canceled" 0 "[]\n" prev2 prev2 prev2 prev2]])
 
 (defn drain-queue []
   (jdbc/delete! db/spec :backtick_queue []))
 
 (defn db-fixtures [f]
   (drain-queue)
-  (apply jdbc/insert! db/spec :backtick_queue backtick-queue-rows)
+  (jdbc/insert-multi! db/spec :backtick_queue backtick-queue-cols backtick-queue-rows)
   (f)
   (drain-queue))
 


### PR DESCRIPTION
The only piece we actually depend on here are the database migrations, and only
for development. Add Ragtime directly as a dev dependency only.
