### PR TITLE
Schedule recurring jobs using a Cron-style specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,20 @@ you may use `define-cron`:
 
 Backtick depends on the
 [clj-cron-parse library](https://github.com/shmish111/clj-cron-parse)
-to parse Cron specifications. You may refer to its documentation for details
-on valid formats.
+to parse Cron specifications. The format is broadly the same as a standard
+crontab, with the addition of seconds in the first position. Briefly:
+
+| field        | allowed values                                           |
+| -----        | --------------                                           |
+| second       | 0-59                                                     |
+| minute       | 0-59                                                     |
+| hour         | 0-23                                                     |
+| day of month | 1-31 L W                                                 |
+| month        | 1-12 (or names)                                          |
+| day of week  | 0-7 (0 or 7 is Sun, or use names) W 1L 2L 3L 4L 5L 6L 7L |
+
+For more details on supported formats, consult
+[clj-cron-parse's documentation](https://github.com/shmish111/clj-cron-parse/blob/master/src/clj_cron_parse/core.clj#L296-L347).
 
 Each of `define-worker`, `define-recurring`, and `define-cron` creates a regular
 Clojure function of the same name.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ job runners can be distributed across multiple machines.
 
 ## Artifacts
 
-`backtick` artifacts are [released to Clojars](https://clojars.org/clj-time/clj-time).
+`backtick` artifacts are [released to Clojars](https://clojars.org/ctdean/backtick).
 
-[![Clojars Project](http://clojars.org/ctdean/backtick/latest-version.svg)](http://clojars.org/ctdean/backtick)
+[![Clojars Project](http://clojars.org/ctdean/backtick/latest-version.svg)](https://clojars.org/ctdean/backtick)
 
 ## Quick start
 
@@ -31,7 +31,7 @@ Backtick will read `:bt-database-url` or failing that will use the
 
 ### Jobs
 
-You configure the jobs using the `define-worker` macro:
+You configure jobs using the `define-worker` macro:
 
 ``` clj
 (require '[backtick.core :as bt])
@@ -48,15 +48,28 @@ and put the job in the queue by calling the `schedule` function:
 (schedule log-sum 88 99)
 ```
 
-You may also run periodic jobs using `define-recurring`
+You may also run periodic jobs using `define-recurring`:
 
 ``` clj
 (bt/define-recurring heartbeat-every-5-minutes (* 1000 60 5) []
   (log/info "heartbeat"))
 ```
 
-Both `define-worker` and `define-recurring` create a regular Clojure
-function of the same name.
+Or if you need you job to run at specific wall clock/calendar times,
+you may use `define-cron`:
+
+```clj
+(bt/define-cron twice-in-the-afternoon "0 0 14,16 * * *" []
+  (log/info "do a thing"))
+```
+
+Backtick depends on the
+[clj-cron-parse library](https://github.com/shmish111/clj-cron-parse)
+to parse Cron specifications. You may refer to its documentation for details
+on valid formats.
+
+Each of `define-worker`, `define-recurring`, and `define-cron` creates a regular
+Clojure function of the same name.
 
 ### Servers
 
@@ -95,8 +108,8 @@ easily handle our load.
 - At job: A job scheduled to run at a particular time in the future.
 - Recurring job: A job scheduled to run repeatedly after a particular time interval
   has elapsed.
+- Cron job: A job that recurs based on the clock or calendar time.
 - Runner: A process that executes a job.
-- Cron: A job that recurs based on the time.
 
 ## Authors
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
-(defproject ctdean/backtick "0.7.5"
+(defproject ctdean/backtick "0.8.0"
   :description "Background job processing for Clojure using Postgres"
   :dependencies [[clj-time "0.12.0"]
+                 [clj-cron-parse "0.1.4"]
                  [clojure.jdbc/clojure.jdbc-c3p0 "0.3.2"]
-                 [conf "0.9.1" :exclusions [org.clojure/clojure]]
+                 [conf "0.9.1"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.391"]
                  [org.clojure/java.jdbc "0.6.1"]

--- a/resources/backtick/migrations/106-cron.down.sql
+++ b/resources/backtick/migrations/106-cron.down.sql
@@ -1,0 +1,49 @@
+ALTER TABLE backtick_recurring DROP CONSTRAINT backtick_recurring_check;
+
+ALTER TABLE backtick_recurring DROP COLUMN cronspec;
+
+ALTER TABLE backtick_recurring ALTER COLUMN interval SET NOT NULL;
+
+-- See migration 104-recurring.up-sql
+CREATE OR REPLACE FUNCTION
+  backtick_upsert_interval(the_name TEXT,
+                           the_interval integer,
+                           the_next timestamp)
+  RETURNS VOID AS
+$$
+  BEGIN
+    LOOP
+      -- A existing job, with the same interval => Do nothing
+      IF EXISTS (SELECT 1 FROM backtick_recurring
+                 WHERE name = the_name AND interval = the_interval)
+      THEN
+        RETURN;
+      END IF;
+
+      -- An existing job, with a new interval => Change the next and
+      -- interval fields.
+      UPDATE backtick_recurring
+        SET
+          interval = the_interval,
+          next = the_next,
+          updated_at = now()
+        WHERE
+          name = the_name;
+      IF FOUND THEN
+        RETURN;
+      END IF;
+
+      -- A new job => insert it
+      BEGIN
+        INSERT INTO backtick_recurring
+          (name, next, interval, created_at, updated_at)
+        VALUES
+          (the_name, the_next, the_interval, now(), now());
+        RETURN;
+      EXCEPTION WHEN unique_violation THEN
+        -- Do nothing, and loop to try the UPDATE again.
+      END;
+    END LOOP;
+  END;
+$$
+LANGUAGE plpgsql;

--- a/resources/backtick/migrations/106-cron.up.sql
+++ b/resources/backtick/migrations/106-cron.up.sql
@@ -1,0 +1,55 @@
+ALTER TABLE backtick_recurring ADD COLUMN cronspec text;
+
+ALTER TABLE backtick_recurring ALTER COLUMN interval DROP NOT NULL;
+
+ALTER TABLE backtick_recurring
+ADD CHECK ((interval IS NULL OR cronspec IS NULL) AND
+           (interval IS NOT NULL OR cronspec IS NOT NULL));
+
+-- See migration 104-recurring.up.sql
+CREATE OR REPLACE FUNCTION
+  backtick_upsert_interval(the_name TEXT,
+                           the_interval integer,
+                           the_cronspec text,
+                           the_next timestamp)
+  RETURNS VOID AS
+$$
+  BEGIN
+    LOOP
+      -- A existing job, with the same interval/cronspec => Do nothing
+      IF EXISTS (SELECT 1 FROM backtick_recurring
+                 WHERE name = the_name
+                 AND interval IS NOT DISTINCT FROM the_interval
+                 AND cronspec IS NOT DISTINCT FROM the_cronspec)
+      THEN
+        RETURN;
+      END IF;
+
+      -- An existing job, with a new interval/cronspec => Change the next,
+      -- interval, and cronspec fields.
+      UPDATE backtick_recurring
+        SET
+          interval = the_interval,
+          cronspec = the_cronspec,
+          next = the_next,
+          updated_at = now()
+        WHERE
+          name = the_name;
+      IF FOUND THEN
+        RETURN;
+      END IF;
+
+      -- A new job => insert it
+      BEGIN
+        INSERT INTO backtick_recurring
+          (name, next, interval, cronspec, created_at, updated_at)
+        VALUES
+          (the_name, the_next, the_interval, the_cronspec, now(), now());
+        RETURN;
+      EXCEPTION WHEN unique_violation THEN
+        -- Do nothing, and loop to try the UPDATE again.
+      END;
+    END LOOP;
+  END;
+$$
+LANGUAGE plpgsql;

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -82,7 +82,7 @@ delete from backtick_recurring where name = :name
 
 -- name: recurring-upsert-interval
 -- Update the interval on an existing recurring job or insert a new one
-select backtick_upsert_interval(:name, :interval, :next);
+select backtick_upsert_interval(:name, :interval, :cronspec, :next);
 
 -- name: recurring-next
 -- Get the next recurring job to run


### PR DESCRIPTION
For recurring jobs that need to run according to the wall clock this allows a
schedule to be specified like Cron, rather than just a repeating interval timeout.
