### PR TITLE
Fix function unquote in core macros

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ctdean/backtick "0.8.0"
+(defproject ctdean/backtick "0.8.1"
   :description "Background job processing for Clojure using Postgres"
   :dependencies [[clj-time "0.12.0"]
                  [clj-cron-parse "0.1.4"]

--- a/src/backtick/core.clj
+++ b/src/backtick/core.clj
@@ -64,10 +64,18 @@
        (~schedulef ~intv-or-cs ~symbol-name))))
 
 (defmacro define-recurring [name interval-ms args & body]
-  (define-recurring* schedule-recurring name interval-ms args body))
+  (define-recurring* 'backtick.core/schedule-recurring
+                     name
+                     interval-ms
+                     args
+                     body))
 
 (defmacro define-cron [name cronspec args & body]
-  (define-recurring* schedule-cron name cronspec args body))
+  (define-recurring* 'backtick.core/schedule-cron
+                     name
+                     cronspec
+                     args
+                     body))
 
 ;;;
 ;;; Cleaners

--- a/src/backtick/db.clj
+++ b/src/backtick/db.clj
@@ -23,8 +23,11 @@
         (str u "?_ignore=_ignore"))))
 
 (def spec
-  (pool/make-datasource-spec
-   {:connection-uri (format-jdbc-url (:db-url master-cf))}))
+  (let [dburl (:db-url master-cf)]
+    (when (nil? dburl)
+      (throw (Exception. "Database URL is not set! Aborting.")))
+    (pool/make-datasource-spec
+     {:connection-uri (format-jdbc-url dburl)})))
 
 (defqueries "sql/backtick.sql"
   {:connection spec})


### PR DESCRIPTION
A function name was not being passed correctly in the core macros
`define-recurring` and `define-cron`. Previously macroexpansion generated code
like this:

```
user=> (macroexpand '(bt/define-recurring testf 999 [] (println ">>> this is it")))
(do
 (clojure.core/defn testf [] (println ">>> this is it"))
  (backtick.registry/register "user/testf" testf)
  (#<Fn@70a5db0d backtick.core/schedule_recurring> 999 testf))
```

Notice that crazy `#<Fn@xxxxxxxx` object? Inexplicably this seems to have been
functioning correctly, but in the interests of readable code, and safety, this
commit fixes it so the correct function _symbol_ is generated there instead.

Additionally unit test coverage has been added for these macros, and a more
informative error message has been added for when the database URL is unset.
