### PR TITLE
Optionally adjust for timezone in cron worker scheduling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ctdean/backtick "0.8.1"
+(defproject ctdean/backtick "0.8.2"
   :description "Background job processing for Clojure using Postgres"
   :dependencies [[clj-time "0.12.0"]
                  [clj-cron-parse "0.1.4"]

--- a/resources/backtick/migrations/107-tz.down.sql
+++ b/resources/backtick/migrations/107-tz.down.sql
@@ -1,0 +1,50 @@
+ALTER TABLE backtick_recurring DROP COLUMN timezone;
+
+-- See migration 106-cron.up.sql
+CREATE OR REPLACE FUNCTION
+  backtick_upsert_interval(the_name TEXT,
+                           the_interval integer,
+                           the_cronspec text,
+                           the_next timestamp)
+  RETURNS VOID AS
+$$
+  BEGIN
+    LOOP
+      -- A existing job, with the same interval/cronspec => Do nothing
+      IF EXISTS (SELECT 1 FROM backtick_recurring
+                 WHERE name = the_name
+                 AND interval IS NOT DISTINCT FROM the_interval
+                 AND cronspec IS NOT DISTINCT FROM the_cronspec)
+      THEN
+        RETURN;
+      END IF;
+
+      -- An existing job, with a new interval/cronspec => Change the next,
+      -- interval, and cronspec fields.
+      UPDATE backtick_recurring
+        SET
+          interval = the_interval,
+          cronspec = the_cronspec,
+          next = the_next,
+          updated_at = now()
+        WHERE
+          name = the_name;
+      IF FOUND THEN
+        RETURN;
+      END IF;
+
+      -- A new job => insert it
+      BEGIN
+        INSERT INTO backtick_recurring
+          (name, next, interval, cronspec, created_at, updated_at)
+        VALUES
+          (the_name, the_next, the_interval, the_cronspec, now(), now());
+        RETURN;
+      EXCEPTION WHEN unique_violation THEN
+        -- Do nothing, and loop to try the UPDATE again.
+      END;
+    END LOOP;
+  END;
+$$
+LANGUAGE plpgsql;
+

--- a/resources/backtick/migrations/107-tz.up.sql
+++ b/resources/backtick/migrations/107-tz.up.sql
@@ -1,0 +1,53 @@
+ALTER TABLE backtick_recurring ADD COLUMN timezone text;
+
+-- See migration 106-cron.up.sql
+CREATE OR REPLACE FUNCTION
+  backtick_upsert_interval(the_name TEXT,
+                           the_interval integer,
+                           the_cronspec text,
+                           the_timezone text,
+                           the_next timestamp)
+  RETURNS VOID AS
+$$
+  BEGIN
+    LOOP
+      -- A existing job, with the same interval/cronspec/tz => Do nothing
+      IF EXISTS (SELECT 1 FROM backtick_recurring
+                 WHERE name = the_name
+                 AND interval IS NOT DISTINCT FROM the_interval
+                 AND cronspec IS NOT DISTINCT FROM the_cronspec
+                 AND timezone IS NOT DISTINCT FROM the_timezone)
+      THEN
+        RETURN;
+      END IF;
+
+      -- An existing job, with a new interval/cronspec/tz => Change the next,
+      -- interval, cronspec, and timezone fields.
+      UPDATE backtick_recurring
+        SET
+          interval = the_interval,
+          cronspec = the_cronspec,
+          timezone = the_timezone,
+          next = the_next,
+          updated_at = now()
+        WHERE
+          name = the_name;
+      IF FOUND THEN
+        RETURN;
+      END IF;
+
+      -- A new job => insert it
+      BEGIN
+        INSERT INTO backtick_recurring
+          (name, next, interval, cronspec, timezone, created_at, updated_at)
+        VALUES
+          (the_name, the_next, the_interval,
+           the_cronspec, the_timezone, now(), now());
+        RETURN;
+      EXCEPTION WHEN unique_violation THEN
+        -- Do nothing, and loop to try the UPDATE again.
+      END;
+    END LOOP;
+  END;
+$$
+LANGUAGE plpgsql;

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -82,7 +82,7 @@ delete from backtick_recurring where name = :name
 
 -- name: recurring-upsert-interval
 -- Update the interval on an existing recurring job or insert a new one
-select backtick_upsert_interval(:name, :interval, :cronspec, :next);
+select backtick_upsert_interval(:name, :interval, :cronspec, :timezone, :next);
 
 -- name: recurring-next
 -- Get the next recurring job to run


### PR DESCRIPTION
Useful when trying to coordinate workers and a wall clock. Will account for odd
timezone effects (like DST) that can't really be solved by manually adjusting
the cronspec.
