### PR TITLE
Add initial-pool-size to pool spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ctdean/backtick "0.8.2"
+(defproject ctdean/backtick "0.8.3"
   :description "Background job processing for Clojure using Postgres"
   :dependencies [[clj-time "0.12.0"]
                  [clj-cron-parse "0.1.4"]

--- a/src/backtick/db.clj
+++ b/src/backtick/db.clj
@@ -27,7 +27,8 @@
     (when (nil? dburl)
       (throw (Exception. "Database URL is not set! Aborting.")))
     (pool/make-datasource-spec
-     {:connection-uri (format-jdbc-url dburl)})))
+     {:connection-uri (format-jdbc-url dburl)
+      :initial-pool-size 3})))
 
 (defqueries "sql/backtick.sql"
   {:connection spec})


### PR DESCRIPTION
Set initial pool size so we don't get this warning when c3p0 initializes pool:
`[WARNING] Bad pool size config, start 0 < min 3. Using 3 as start`