### PR TITLE
Use PG skip locked when reading from the queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /app.log
 /checkouts
 /classes
+/project.clj.save
 /st.com.bind
 /st.net.bind
 /target

--- a/resources/sql/backtick.sql
+++ b/resources/sql/backtick.sql
@@ -11,7 +11,7 @@ from (
    where state = 'queued' and priority <= now() and queue_name = :queue_name
    order by priority
    limit 1
-   for update
+   for update skip locked
    ) sub
 where
   bq.id = sub.id


### PR DESCRIPTION
See skip locked at
https://www.postgresql.org/docs/9.5/sql-select.html#SQL-FOR-UPDATE-SHARE

This should improve the queue popping performance.