### PR TITLE
Make the entire payload available as a dynamic var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ test_refresh:
 	CONF_ENV=test lein test-refresh
 
 .PHONY: test
+
+deploy:
+	lein deploy tprime

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
 (defproject ctdean/backtick
-  "1.5.1"
+  "1.5.2"
   :description "A background job processor"
+  :license :eclipse
   :dependencies
   [
    [cider/cider-nrepl "0.14.0" :scope "test"]
@@ -18,8 +19,11 @@
    [org.postgresql/postgresql "9.4.1211"]
    [treasuryprime/common "1.3.0"]
    ]
-  :plugins [[com.jakemccrary/lein-test-refresh "0.22.0"]]
+  :plugins [[s3-wagon-private "1.3.2"]
+            [com.jakemccrary/lein-test-refresh "0.22.0"]]
   :profiles {:test {:jvm-opts ["-Dconf.env=test"]}}
+  :repositories
+  [["tprime" {:url "s3p://treasuryprime-jars/releases/" :no-auth true}]]
   :test-refresh {:quiet true
                  :changes-only true}
   )

--- a/src/backtick/cleaner.clj
+++ b/src/backtick/cleaner.clj
@@ -21,10 +21,10 @@
 
 (defn- time-unit [x]
   (cond
-   (< x 1000) (format "%3.1f %5s" x "ms")
-   (< x (* 60 1000)) (format "%3.1f %5s" (/ x 1000.0) "secs")
-   (< x (* 60 60 1000)) (format "%3.1f %5s" (/ x 60 1000.0) "mins")
-   :else (format "%3.1f %5s" (/ x 60 60 1000.0) "hours")))
+    (< x 1000) (format "%3.1f %5s" x "ms")
+    (< x (* 60 1000)) (format "%3.1f %5s" (/ x 1000.0) "secs")
+    (< x (* 60 60 1000)) (format "%3.1f %5s" (/ x 60 1000.0) "mins")
+    :else (format "%3.1f %5s" (/ x 60 60 1000.0) "hours")))
 
 (defn- dump-revive-range
   "Print the possible revive times.  Useful for debugging."
@@ -49,9 +49,9 @@
      (log/errorf "No id for revive-one-job: %s" id)))
   ([id tries]
    (if (exceeded? tries)
-     (db/queue-abort-job! {:id id})
-     (db/queue-requeue-job! {:id id
-                             :priority (revive-at tries)}))))
+       (db/queue-abort-job! {:id id})
+       (db/queue-requeue-job! {:id id
+                               :priority (revive-at tries)}))))
 
 (defn revive
   "Revive jobs that never finished.  Will be run from a backtick job."


### PR DESCRIPTION
We add the `*job-payload*` dynamic variable that is available to all
jobs. That way each job can customize the behavior based on how many
times this job has been attempted.